### PR TITLE
props name fullheight to fullHeight and modify height

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The `Dashboard` component requires the following props:
   to retrieve data from Superset.
 - `domain`: the domain where Superset is running.
 - `uuid`: the uuid of the dashboard to render.
-- `fullheight`: if true, the dashboard will take the full height of the
+- `fullHeight`: if true, the dashboard will take the full height of the
   container. Default: `false`.
 - `guestToken`: you can pass a guest token to the component. If not provided,
   the component will use the `dataProvider` to retrieve one.

--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -51,7 +51,7 @@ function App() {
       uuid={RESOURCE_UUID}
       domain={SUPERSET_DOMAIN}
       dataProvider={dataProvider}
-      fullheight
+      fullHeight
       guestToken={guestToken}
       filters={[
         {

--- a/src/Dashboard/Dashboard.scss
+++ b/src/Dashboard/Dashboard.scss
@@ -1,6 +1,6 @@
 .superset-dashboard {
   width: 100%;
-  height: calc(100vh - 300px);
+  height: inherit;
   border: 0;
   & iframe {
     width: 100%;

--- a/src/Dashboard/Dashboard.stories.tsx
+++ b/src/Dashboard/Dashboard.stories.tsx
@@ -21,7 +21,7 @@ export const Scrollable = () => (
 export const FullHeight = () => (
   <Dashboard
     uuid="4c2374d1-6371-4793-859c-d834a5cae7d5"
-    fullheight
+    fullHeight
     domain="http://localhost:8088"
     dataProvider={localDataProvider}
   />

--- a/src/Dashboard/Dashboard.tsx
+++ b/src/Dashboard/Dashboard.tsx
@@ -10,7 +10,7 @@ import { formatNativeFilter } from "./Embedded/NativeFilter";
 const Dashboard = ({
   uuid,
   domain,
-  fullheight = false,
+  fullHeight = false,
   dataProvider,
   guestToken,
   nativeFilters,
@@ -58,7 +58,7 @@ const Dashboard = ({
           },
         },
       });
-      if (!fullheight) {
+      if (!fullHeight) {
         return;
       }
       const sizeWatcher = setInterval(async () => {
@@ -79,12 +79,12 @@ const Dashboard = ({
         clearInterval(sizeWatcher);
       };
     })();
-  }, [ref.current, uuid, fullheight]);
+  }, [ref.current, uuid, fullHeight]);
 
   return (
     <div
       className={`superset-dashboard ${
-        fullheight ? "superset-dashboard-fullheight" : ""
+        fullHeight ? "superset-dashboard-fullheight" : ""
       }`}
       ref={ref}
     />

--- a/src/Dashboard/Dashboard.types.ts
+++ b/src/Dashboard/Dashboard.types.ts
@@ -8,10 +8,10 @@ export type DashboardProps = {
   /** The uuid of the dashboard to display. */
   uuid: string;
   /**
-   * Indicates whether the dashboard should be displayed in fullheight mode.
+   * Indicates whether the dashboard should be displayed in fullHeight mode.
    * In that case the dashboard will try to fit itself adding scrollbar to the container.
    */
-  fullheight?: boolean;
+  fullHeight?: boolean;
   /** Superset domain. */
   domain: string;
   /** Superset dashboard config */


### PR DESCRIPTION
changed props name fullheight to fullHeight in all the places.

modified height `height: calc(100vh - 300px);` to `height: inherit;` because this fixed height might not be appropriate for everyone. I think if the height is set to inherit that the iframe height can be modified from outside which is ideal.

Also, I think the fullHeight props shouldn't even exist here. iframe by default has a scrollbar, an external scrollbar is not needed. By default height filter panel remains on the screen but with full height one has to scroll all the way down to click the apply filter button which is very annoying. 

The below image is without full height and with `height: initial`
![image](https://github.com/RoBYCoNTe/superset-dashboard-sdk/assets/48943431/b262987d-609d-445a-b079-0b5184d0f7f3)

The image below is at full height. I had to scroll this much to reach the `apply filter` button.
![image](https://github.com/RoBYCoNTe/superset-dashboard-sdk/assets/48943431/919df28e-2dbe-4d84-8cbd-90763fec35eb)
